### PR TITLE
Add fudge dice

### DIFF
--- a/src/DiceExpression.js
+++ b/src/DiceExpression.js
@@ -22,7 +22,7 @@ function validate(){
       validStart = !(this.operations[0] instanceof DiceOperator);
       validEnd = !(this.operations[this.operations.length-1] instanceof DiceOperator);
     }
-    
+
     isValid = hasRolls && operationsValid && validStart && validEnd;
     
   }
@@ -75,7 +75,7 @@ function toString(){
 
 function DiceExpression(expr){
   var operations = [];
-  var diceNotation = /^\s*([+-])?\s*(\d*)d(\d+)([^\s+-]*)/i;
+  var diceNotation = /^\s*([+-])?\s*(\d*)d(\d+|f)([^\s+-]*)/i;
   
   var special = specialFunctions.getSpecial(expr);
   if(special){

--- a/src/DiceRoll.js
+++ b/src/DiceRoll.js
@@ -1,10 +1,23 @@
 var RollOptions = require('./RollOptions');
 
+var constantExpressions = {
+  'f': function () {
+    var sides = [-1, 0, 1];
+    var choice = Math.floor(Math.random() * sides.length);
+    return sides[choice];
+  }
+};
+
 function roll(numberOfFaces){
   var primer = new Date().getTime() % 10;
   for(var jk = 0; jk < primer; jk++){
     Math.random();
   }
+
+  if (constantExpressions.hasOwnProperty(numberOfFaces)) {
+    return constantExpressions[numberOfFaces]();
+  }
+
   return Math.ceil(numberOfFaces * Math.random());
 }
 
@@ -51,7 +64,10 @@ function toString(){
 function DiceRoll(numDice, numFaces, options){
   if(!numDice) numDice = '1';
   this.numberOfDice = parseInt(numDice, 10);
-  this.numberOfFaces = parseInt(numFaces, 10);
+  if (constantExpressions.hasOwnProperty(numFaces))
+    this.numberOfFaces = numFaces;
+  else
+    this.numberOfFaces = parseInt(numFaces, 10);
   this.rollOptions = new RollOptions(options);
   this.results = {
     raw: [],
@@ -64,11 +80,13 @@ function DiceRoll(numDice, numFaces, options){
     this.numberOfDice = 1000;
     this.niceTry = true;
   }
+
+  var numFacesAcceptable = (!isNaN(this.numberOfFaces) && this.numberOfFaces > 1) ||
+                           constantExpressions.hasOwnProperty(this.numberOfFaces);
   
   this.isValid = !isNaN(this.numberOfDice)
-    && !isNaN(this.numberOfFaces)
+    && numFacesAcceptable
     && this.rollOptions.isValid
-    && this.numberOfFaces > 1
     && this.numberOfDice > 0;
     
   this.execute = execute.bind(this);


### PR DESCRIPTION
Adds Fudge dice, used in the [Fudge RPG](https://en.wikipedia.org/wiki/Fudge_%28role-playing_game_system%29) and more commonly in [Fate](http://www.faterpg.com/). 6 sided die, two faces are +, two are -, two are neutral. In Fate you'd roll 4 of these, creating a nice normal distribution from -4 to +4, mean 0. 

Still need to add the syntax to the syntax string thingy.

Will mostly be used like: roll 4df.

@mentalspike Check it, bruh.

![image](https://cloud.githubusercontent.com/assets/3706543/15639075/6e7cf51c-25f5-11e6-8c50-594842751bbf.png)
